### PR TITLE
Boilerplate for dns query handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Welcome to TundraDNS, your DNS management solution built as a project for the
 UQCS 2023 Hackathon. Effortlessly manage records, optimize traffic, and enhance 
 your online presence. Join us on this hackathon journey with TundraDNS!
 
-> **Note:** You can view an overview of the project plan [here](./PLAN.md).
+You can view an overview of the project plan [here](./PLAN.md).
 
-**Key Features**
+## Key Features
 
 TundraDNS offers a range of powerful features tailored to simplify and enhance the management of DNS records. Though these are designed to be accessed via a WebApp, all the features will be API compatible.
 

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -2,66 +2,13 @@ package main
 
 import (
 	"fmt"
-	"net"
-	"sync"
 
-	"github.com/miekg/dns"
+	"github.com/lcox74/tundra-dns/backend/internal/routing"
 )
-
-// Testing out go memory pools to see if it helps with performance. Very much
-// not needed for this project, but I want to learn how to use them.
-var responsePool = sync.Pool{
-	New: func() interface{} {
-		return &dns.Msg{}
-	},
-}
-
-func handleDNSRequest(w dns.ResponseWriter, r *dns.Msg) {
-	// Check if the message is a query
-	if r.MsgHdr.Response {
-		return
-	}
-
-	// Get the question from the message
-	for _, q := range r.Question {
-		fmt.Printf("Received query for %s type %s and class %s\n", q.Name, dns.TypeToString[q.Qtype], dns.ClassToString[q.Qclass])
-	}
-
-	// Get a response from the pool
-	response := responsePool.Get().(*dns.Msg)
-	defer responsePool.Put(response)
-
-	// Clear the response data
-	response.Answer = make([]dns.RR, 0)
-	response.Ns = nil
-	response.Extra = nil
-
-	// Set the response header
-	response.SetReply(r)
-	response.Answer = append(response.Answer, &dns.A{
-		Hdr: dns.RR_Header{
-			Name:   "example.com.",
-			Rrtype: dns.TypeA,
-			Class:  dns.ClassINET,
-			Ttl:    300,
-		},
-		A: net.ParseIP("10.10.10.10"),
-	})
-
-	w.WriteMsg(response)
-}
 
 func main() {
 	fmt.Println("Hello, World!")
 
-	// Attach a function to handle DNS requests
-	server := &dns.Server{Addr: ":53", Net: "udp"}
-	dns.HandleFunc(".", handleDNSRequest)
-
-	// Run the DNS Server
-	fmt.Println("Starting DNS Server")
-	err := server.ListenAndServe()
-	if err != nil {
-		fmt.Println(err)
-	}
+	// Launch the DNS Query Handler
+	routing.LaunchDNSQueryHandler()
 }

--- a/backend/internal/routing/dns_query_handler.go
+++ b/backend/internal/routing/dns_query_handler.go
@@ -1,0 +1,70 @@
+package routing
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/miekg/dns"
+)
+
+func LaunchDNSQueryHandler() {
+	// Attach a function to handle DNS requests
+	server := &dns.Server{Addr: ":53", Net: "udp"}
+	dns.HandleFunc(".", handleDNSRequest)
+
+	// Run the DNS Server
+	fmt.Println("Starting DNS Server")
+	err := server.ListenAndServe()
+	if err != nil {
+		fmt.Println(err)
+	}
+}
+
+func handleDNSQuery(queryType string, fqdn string) *dns.RR {
+	return nil
+}
+
+// Testing out go memory pools to see if it helps with performance. Very much
+// not needed for this project, but I want to learn how to use them.
+var responsePool = sync.Pool{
+	New: func() interface{} {
+		return &dns.Msg{}
+	},
+}
+
+func handleDNSRequest(w dns.ResponseWriter, r *dns.Msg) {
+	// Check if the message is a query
+	if r.MsgHdr.Response {
+		return
+	}
+
+	if len(r.Question) < 1 {
+		return
+	}
+
+	// Get a response from the pool
+	response := responsePool.Get().(*dns.Msg)
+	defer responsePool.Put(response)
+
+	// Clear the response data
+	response.Answer = make([]dns.RR, 0)
+	response.Ns = nil
+	response.Extra = nil
+
+	// Set the response header
+	response.SetReply(r)
+
+	// Get the question from the message
+	for _, q := range r.Question {
+		var rr *dns.RR
+		if rr = handleDNSQuery(dns.TypeToString[q.Qtype], q.Name); rr == nil {
+			response.SetRcode(r, dns.RcodeNameError)
+			break
+		}
+
+		// Add the answer to the response
+		response.Answer = append(response.Answer, *rr)
+	}
+
+	w.WriteMsg(response)
+}


### PR DESCRIPTION
The DNS query handler is now its own separate module which must be launched by the main program. It has a placeholder function which will be used for properly resolving requests once the routing table is built.

```go
func handleDNSQuery(queryType string, fqdn string) *dns.RR
```