### PR TITLE
Initialising Routing Table

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.20-alpine as builder
+
+WORKDIR /app
+
+RUN apk add --update gcc musl-dev
+
+COPY . /app
+RUN go mod download
+
+RUN CGO_ENABLED=1 GOOS=linux go build -o /app/tundra-dns ./cmd/main.go
+
+FROM alpine:latest as production
+COPY --from=builder /app/tundra-dns .
+CMD ["./tundra-dns"]

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,7 +5,10 @@ go 1.20
 require github.com/miekg/dns v1.1.55
 
 require (
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/mattn/go-sqlite3 v1.14.17 // indirect
+	github.com/redis/go-redis/v9 v9.1.0 // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.2.0 // indirect
 	golang.org/x/sys v0.2.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,7 +1,13 @@
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
 github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/miekg/dns v1.1.55 h1:GoQ4hpsj0nFLYe+bWiCToyrBEJXkQfOOIvFGFy0lEgo=
 github.com/miekg/dns v1.1.55/go.mod h1:uInx36IzPl7FYnDcMeVWxj9byh7DutNykX4G9Sj60FY=
+github.com/redis/go-redis/v9 v9.1.0 h1:137FnGdk+EQdCbye1FW+qOEcY5S+SpY9T0NiuqvtfMY=
+github.com/redis/go-redis/v9 v9.1.0/go.mod h1:urWj3He21Dj5k4TK1y59xH8Uj6ATueP8AH1cY3lZl4c=
 golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
 golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.2.0 h1:sZfSu1wtKLGlWI4ZZayP0ck9Y73K1ynO6gqzTdBVdPU=

--- a/backend/internal/database/redis.go
+++ b/backend/internal/database/redis.go
@@ -1,0 +1,67 @@
+package database
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lcox74/tundra-dns/backend/internal/models"
+	"github.com/redis/go-redis/v9"
+)
+
+var ctx = context.Background()
+
+func InitialiseRedisDb(host string, port string) (*redis.Client, error) {
+	// Create a new Redis client
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     fmt.Sprintf("%s:%s", host, port),
+		Password: "", // No password set
+		DB:       0,  // Default DB
+	})
+
+	if rdb == nil {
+		return nil, fmt.Errorf("failed to initialise redis database")
+	}
+
+	return rdb, nil
+}
+
+func generateHashKey(recordType string, fqdn string) string {
+	return fmt.Sprintf("%s:%s", recordType, fqdn)
+}
+
+func FetchRecordCache(rdb *redis.Client, recordType string, fqdn string) (models.DNSRecord, error) {
+	// Generate the hash key
+	hashKey := generateHashKey(recordType, fqdn)
+
+	fmt.Println("Fetch:", hashKey)
+
+	// Get the record from the database
+	record, err := rdb.Get(ctx, hashKey).Result()
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the record
+	return models.UnmarshalJSON([]byte(record))
+}
+
+func PublishRecordCache(rdb *redis.Client, record models.DNSRecord) error {
+	// Generate the hash key
+	hashKey := generateHashKey(record.GetCommon().GetType(), record.GetCommon().GetFQDN())
+
+	fmt.Println("Publish:", hashKey)
+
+	// Marshal the record
+	recordData, err := models.MarshalJSON(record)
+	if err != nil {
+		return err
+	}
+
+	// Publish the record to the database
+	err = rdb.Set(ctx, hashKey, recordData, 0).Err()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/backend/internal/models/record.go
+++ b/backend/internal/models/record.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -48,7 +49,7 @@ type RecordCommon struct {
 }
 
 func (r RecordCommon) GetFQDN() string {
-	return r.Subdomain + "." + r.Domain
+	return r.Subdomain + "." + r.Domain + "."
 }
 
 func (r RecordCommon) GetType() string {
@@ -67,4 +68,25 @@ func ParseRecord(common RecordCommon, data []byte) (DNSRecord, error) {
 	default:
 		return nil, fmt.Errorf("unsupported record type")
 	}
+}
+
+func UnmarshalJSON(data []byte) (DNSRecord, error) {
+	var common RecordCommon
+	err := json.Unmarshal(data, &common)
+	if err != nil {
+		return nil, err
+	}
+
+	switch common.Type {
+	case A:
+		var ARecord ARecord
+		err = json.Unmarshal(data, &ARecord)
+		return &ARecord, err
+	}
+
+	return nil, fmt.Errorf("unsupported record type")
+}
+
+func MarshalJSON(record DNSRecord) ([]byte, error) {
+	return json.Marshal(record)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.8"
+
+services:
+  redis:
+    container_name: tundra-redis
+    image: redis:6.0.9-alpine
+    ports:
+      - 6379:6379
+  
+  tundra:
+    container_name: tundra-dns
+    build: 
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - 53:53/udp
+    depends_on:
+      - redis
+    environment:
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+
+    


### PR DESCRIPTION
Initialised the Redis routing table for the DNS query handler. Currently it will dump all the records from the database into the routing table at start up. These routes will also resolve accordingly (though only `A Record` is implemented).

You can run the program by running:

```bash
docker compose up --build
```