### PR TITLE
Basic API at :8053

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/lcox74/tundra-dns/backend/internal/api"
 	"github.com/lcox74/tundra-dns/backend/internal/database"
 	"github.com/lcox74/tundra-dns/backend/internal/models"
 	"github.com/lcox74/tundra-dns/backend/internal/routing"
@@ -37,8 +38,13 @@ func main() {
 	populateRecords(db)
 	populateRoutingTable(db, rdb)
 
-	// Launch the DNS Query Handler
+	// TODO: Create Routing Engine Here...
+
+	// Launch the DNS Query Handler and API Router
+	go api.LaunchRouter(db)
 	routing.LaunchDNSQueryHandler(rdb)
+
+	// TODO: Launch Routing Engine Here...
 }
 
 func populateRecords(db *sql.DB) {

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,6 +7,7 @@ require github.com/miekg/dns v1.1.55
 require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/mattn/go-sqlite3 v1.14.17 // indirect
 	github.com/redis/go-redis/v9 v9.1.0 // indirect
 	golang.org/x/mod v0.7.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -2,6 +2,8 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6YIM=
 github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/miekg/dns v1.1.55 h1:GoQ4hpsj0nFLYe+bWiCToyrBEJXkQfOOIvFGFy0lEgo=

--- a/backend/internal/api/api.go
+++ b/backend/internal/api/api.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/lcox74/tundra-dns/backend/internal/database"
+)
+
+func LaunchRouter(db *sql.DB) {
+	r := mux.NewRouter()
+
+	// API Route GET /api/records
+	r.HandleFunc("/api/records", func(w http.ResponseWriter, r *http.Request) {
+		GetRecords(db, w, r)
+	}).Methods("GET")
+
+	http.ListenAndServe(":8053", r)
+}
+
+func GetRecords(db *sql.DB, w http.ResponseWriter, r *http.Request) {
+	fmt.Println("GetRecords")
+
+	rawRecords, err := database.GetDNSRecords(db)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Println(err)
+		return
+	}
+
+	// Convert to JSON
+	jsonRecords, err := json.Marshal(rawRecords)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Println(err)
+		return
+	}
+
+	// Write JSON to ResponseWriter
+	w.Write(jsonRecords)
+}

--- a/backend/internal/database/sqlite.go
+++ b/backend/internal/database/sqlite.go
@@ -189,15 +189,15 @@ func scanToRecord(row *sql.Row) (models.DNSRecord, error) {
 	}
 
 	// Parse the timestamps.
-	recordCommon.CreatedAt, _ = time.Parse(time.DateTime, createdAt)
-	recordCommon.UpdatedAt, _ = time.Parse(time.DateTime, updatedAt)
+	recordCommon.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+	recordCommon.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt)
 
 	// Parse the nullable timestamps.
 	if deactivatedAt.Valid {
-		recordCommon.DeactivatedAt, _ = time.Parse(time.DateTime, deactivatedAt.String)
+		recordCommon.DeactivatedAt, _ = time.Parse(time.RFC3339, deactivatedAt.String)
 	}
 	if expiredAt.Valid {
-		recordCommon.ExpiredAt, _ = time.Parse(time.DateTime, expiredAt.String)
+		recordCommon.ExpiredAt, _ = time.Parse(time.RFC3339, expiredAt.String)
 	}
 
 	// Parse the allow and deny lists.
@@ -244,15 +244,15 @@ func scanToRecordRows(rows *sql.Rows) (models.DNSRecord, error) {
 	}
 
 	// Parse the timestamps.
-	recordCommon.CreatedAt, _ = time.Parse(time.DateTime, createdAt)
-	recordCommon.UpdatedAt, _ = time.Parse(time.DateTime, updatedAt)
+	recordCommon.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+	recordCommon.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt)
 
 	// Parse the nullable timestamps.
 	if deactivatedAt.Valid {
-		recordCommon.DeactivatedAt, _ = time.Parse(time.DateTime, deactivatedAt.String)
+		recordCommon.DeactivatedAt, _ = time.Parse(time.RFC3339, deactivatedAt.String)
 	}
 	if expiredAt.Valid {
-		recordCommon.ExpiredAt, _ = time.Parse(time.DateTime, expiredAt.String)
+		recordCommon.ExpiredAt, _ = time.Parse(time.RFC3339, expiredAt.String)
 	}
 
 	// Parse the allow and deny lists.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     ports:
+      - 8053:8053/tcp # Change to listen on Tailscale IP
       - 53:53/udp
     depends_on:
       - redis


### PR DESCRIPTION
A basic API is now setup and can perform `GET /api/records` to fetch all available records in the DB. The restriction on how the port is exposed is handled by the `docker-compose.yml` file.